### PR TITLE
Fix build with automake 1.13

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_CONFIG_SRCDIR(src/cinnamon-screensaver.c)
 AM_INIT_AUTOMAKE([1.10 no-dist-gzip dist-xz tar-ustar])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 
 AM_MAINTAINER_MODE([enable])
 


### PR DESCRIPTION
This change fixes the build with automake-1.13. Without this change, the build fails with the following error:

Running aclocal-1.13...
configure.ac:13: error: 'AM_CONFIG_HEADER': this macro is obsolete.
    You should use the 'AC_CONFIG_HEADERS' macro instead.
/usr/share/aclocal-1.13/obsolete-err.m4:12: AM_CONFIG_HEADER is expanded from...
configure.ac:13: the top level
autom4te: /usr/bin/m4 failed with exit status: 1
aclocal-1.13: error: echo failed with exit status: 1
