### PR TITLE
Fix and improve systemd compatibility

### DIFF
--- a/src/gs-listener-dbus.c
+++ b/src/gs-listener-dbus.c
@@ -786,19 +786,8 @@ _listener_message_path_is_our_session (GSListener  *listener,
         if (listener->priv->session_id == NULL)
                 return FALSE;
 
-#ifdef WITH_SYSTEMD
-        /* The bus object path is simply the actual session ID
-         * prefixed to make it a bus path */
-        if (listener->priv->have_systemd)
-                return g_str_has_prefix (ssid, SYSTEMD_LOGIND_SESSION_PATH "/")
-                        && strcmp (ssid + sizeof (SYSTEMD_LOGIND_SESSION_PATH),
-                                   listener->priv->session_id) == 0;
-#endif
-
-#ifdef WITH_CONSOLE_KIT
         if (strcmp (ssid, listener->priv->session_id) == 0)
                 return TRUE;
-#endif
 
         return FALSE;
 }
@@ -1457,20 +1446,37 @@ query_session_id (GSListener *listener)
 
 #ifdef WITH_SYSTEMD
         if (listener->priv->have_systemd) {
-                char *t;
-                int r;
+                dbus_uint32_t pid = getpid();
 
-                r = sd_pid_get_session (0, &t);
-                if (r < 0) {
-                        gs_debug ("Couldn't determine our own session id: %s", strerror (-r));
+                message = dbus_message_new_method_call (SYSTEMD_LOGIND_SERVICE, SYSTEMD_LOGIND_PATH, SYSTEMD_LOGIND_INTERFACE, "GetSessionByPID");
+                if (message == NULL) {
+                        gs_debug ("Couldn't allocate the dbus message");
                         return NULL;
                 }
 
-                /* t is allocated with malloc(), we need it with g_malloc() */
-                ssid = g_strdup(t);
-                free (t);
+                if (dbus_message_append_args (message, DBUS_TYPE_UINT32, &pid, DBUS_TYPE_INVALID) == FALSE) {
+                        gs_debug ("Couldn't add args to the dbus message");
+                        return NULL;
+                }
 
-                return ssid;
+                /* FIXME: use async? */
+                reply = dbus_connection_send_with_reply_and_block (listener->priv->system_connection,
+                                                                   message,
+                                                                   -1, &error);
+                dbus_message_unref (message);
+
+                if (dbus_error_is_set (&error)) {
+                        gs_debug ("%s raised:\n %s\n\n", error.name, error.message);
+                        dbus_error_free (&error);
+                        return NULL;
+                }
+
+                dbus_message_iter_init (reply, &reply_iter);
+                dbus_message_iter_get_basic (&reply_iter, &ssid);
+
+                dbus_message_unref (reply);
+
+                return g_strdup (ssid);
         }
 #endif
 


### PR DESCRIPTION
Use the session path instead of the session id.
Lock and Unlock D-Bus calls are fail to work with recent systemd due to some changes. This change fixes the problem. The patch comes from the light-locker project:
https://github.com/the-cavalry/light-locker/commit/cac2c0ad8f4f40b6b175b9fbcde06935859f1bbc

 Test case: run the 'loginctl lock-sessions' command as root. Cinnamon Screensaver should lock the session.
