### PR TITLE
Add back support for user switch with GDM

### DIFF
--- a/src/gs-lock-plug.c
+++ b/src/gs-lock-plug.c
@@ -1119,7 +1119,7 @@ gs_lock_plug_set_switch_enabled (GSLockPlug *plug,
                     g_getenv("XDG_SEAT_PATH")) {
                         gtk_widget_show (plug->priv->auth_switch_button);
                 } else {
-                        gs_debug ("Waring: no compatible display manager found");
+                        gs_debug ("Warning: no compatible display manager found");
                         gtk_widget_hide (plug->priv->auth_switch_button);
                 }
         } else {


### PR DESCRIPTION
With this change, both MDM, GDM and LightDM (or compatible) display managers are supported. If no MDM or GDM is running, then try the standard org.freedesktop.DisplayManager D-Bus interface.

The process_is_running function is come from the cinnamon-session project.
