### PR TITLE
Fixed a transparency issue with certain themes.

### DIFF
--- a/src/gs-window-x11.c
+++ b/src/gs-window-x11.c
@@ -2203,6 +2203,15 @@ gs_window_init (GSWindow *window)
         GtkWidget *main_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
         GtkWidget *grid = gtk_grid_new();
+
+        GdkColor transparentColor = {
+            .red = 0,
+            .green = 0,
+            .blue = 0,
+            .alpha = 0
+        };
+
+        gtk_widget_override_background_color(grid, GTK_STATE_NORMAL, &transparentColor);
         gtk_widget_show (grid);
                      
         window->priv->vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);


### PR DESCRIPTION
I use the MediterraneanDarkest theme with Mint. It worked very well with Mint 16 Cinnamon.

![Cinnamon and MediterraneanDarkest](https://cloud.githubusercontent.com/assets/466838/3139721/2e94df8e-e8ec-11e3-8bbe-b002051b10a7.png)

There was a regression with Mint 17 where the grid container of the cinnamon-screensaver would be filled with the background color of my theme. This started to get under my skin more and more over the past week so I decided to fix it.

![MediterraneanDarkest Issue](https://cloud.githubusercontent.com/assets/466838/3139723/6ec17e1e-e8ec-11e3-832f-c94ca6970778.png)

If I use the Mint-X theme there is no issue.

![Mint-X No Issue](https://cloud.githubusercontent.com/assets/466838/3139728/8815ba06-e8ec-11e3-97cb-989c768c5e89.png)

I patched gs-window-x11.c to override the background of the grid container with a transparent color. Here is the test-window utility before applying this patch.

![Pre-Patch](https://cloud.githubusercontent.com/assets/466838/3139731/c741d048-e8ec-11e3-9b77-af1f316ab6fd.png)

Here is the test-window utility after applying this patch.

![Post-Patch](https://cloud.githubusercontent.com/assets/466838/3139733/d6c15dfe-e8ec-11e3-9f60-a84814e57a92.png)

Finally, here is the patched cinnamon-screensaver build running as my screensaver under normal conditions.

![Fixed with MediterraneanDarkest](https://cloud.githubusercontent.com/assets/466838/3139735/e6ddef0e-e8ec-11e3-8ac9-1e87d955e6a5.png)

This change has no impact on the Mint-X theme.

![Fixed with Mint-X](https://cloud.githubusercontent.com/assets/466838/3139739/17520792-e8ed-11e3-9e35-bd0108d97edf.png)

I know that it is unusual to override the color of a widget under GTK, but this seems harmless. I believe cinnmon-screensaver was designed such that the clock text is sitting on a transparent background atop the users wallpaper.

On these grounds, I hope you will accept my pull request.
