### PR TITLE
Add ability to display custom date/time format from schema seperate from...

### DIFF
--- a/src/cinnamon-screensaver.desktop.in
+++ b/src/cinnamon-screensaver.desktop.in
@@ -12,4 +12,4 @@ X-GNOME-Autostart-Notify=true
 X-GNOME-Bugzilla-Bugzilla=GNOME
 X-GNOME-Bugzilla-Product=cinnamon-screensaver
 X-GNOME-Bugzilla-Component=general
-X-GNOME-Bugzilla-Version=2.2.3
+X-GNOME-Bugzilla-Version=2.3.0

--- a/src/gs-window-x11.c
+++ b/src/gs-window-x11.c
@@ -2224,7 +2224,7 @@ gs_window_init (GSWindow *window)
         gtk_widget_set_size_request(window->priv->vbox,450, -1);
         
         // Default message        
-        window->priv->default_message = g_settings_get_string(g_settings_new ("org.cinnamon.screensaver"), "default-message");
+        window->priv->default_message = g_settings_get_string(g_settings_new ("org.cinnamon.desktop.screensaver"), "default-message");
                 
         // Clock -- need to find a way to make it appear on the bottom-left side of the background without shifting the position of the main dialog box
         window->priv->clock = gtk_label_new (NULL);


### PR DESCRIPTION
... cinnamon desktop wallclock, this matches the other clock shaped things in the cinnamon desktop

Depends on linuxmint/cinnamon-desktop#16 for schema and not dependant but useful https://github.com/linuxmint/Cinnamon/pull/3404 for settings

![screenshot from 2014-07-15 03 01 29](https://cloud.githubusercontent.com/assets/1816681/3582625/bcfe03f6-0bfe-11e4-8abb-6a08e08b0cad.png)
