### PR TITLE
Remove circular dependency with Cinnamon

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,6 @@ Depends: ${shlibs:Depends},
          dbus-x11,
          gnome-icon-theme (>= 2.15.90),
          cinnamon-desktop-data (>= 1.0.0),
-         cinnamon,
          cinnamon-translations
 Recommends: gnome-power-manager | xfce4-power-manager,
             libpam-gnome-keyring

--- a/debian/control.in
+++ b/debian/control.in
@@ -35,7 +35,6 @@ Depends: ${shlibs:Depends},
          dbus-x11,
          gnome-icon-theme (>= 2.15.90),
          cinnamon-desktop-data (>= 1.0.0),
-         cinnamon,
          cinnamon-translations
 Recommends: gnome-power-manager | xfce4-power-manager,
             libpam-gnome-keyring


### PR DESCRIPTION
Reported here:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=755190
Already solved in debian's package git for next build.
