### PR TITLE
Do not return from check_gamma_extension, it's void

### DIFF
--- a/src/gs-fade.c
+++ b/src/gs-fade.c
@@ -420,7 +420,8 @@ check_gamma_extension (GSFade *fade, int screen_idx)
 
 #ifdef HAVE_XF86VMODE_GAMMA
 	if (g_getenv("LTSP_CLIENT")) {
-		return FADE_TYPE_NONE;  /* We're on an LTSP Client, bad idea to fade at all */
+		/* We're on an LTSP Client, bad idea to fade at all */
+                goto fade_none;
 	}
 
         res = XF86VidModeQueryExtension (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), &event, &error);


### PR DESCRIPTION
check_gamma_extension is a void function.  The current code returns a value from it when it detects LTSP_CLIENT in the environment, this makes cinnamon-screensaver not compile with Clang, because it fails in this situation.

The function already includes a fade_none label that does the right thing and is used in all other situations where there should be no fade.
