### PR TITLE
Ignore Clang warnings related to variable format strings

### DIFF
--- a/src/gs-debug.c
+++ b/src/gs-debug.c
@@ -57,7 +57,10 @@ gs_debug_real (const char *func,
 
         va_start (args, format);
 
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wformat-nonliteral"
         g_vsnprintf (buffer, 1024, format, args);
+        #pragma clang diagnostic pop
 
         va_end (args);
 

--- a/src/gs-listener-dbus.c
+++ b/src/gs-listener-dbus.c
@@ -359,7 +359,10 @@ raise_error (DBusConnection *connection,
 
         va_list args;
         va_start (args, format);
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wformat-nonliteral"
         vsnprintf (buf, sizeof (buf), format, args);
+        #pragma clang diagnostic pop
         va_end (args);
 
         gs_debug (buf);


### PR DESCRIPTION
Using a variable for format strings is considered an error for Clang.  Adding these #pragma comments allows to ignore these particular instances of the issue and lets cinnamon-screensaver compile correctly under Clang.
