### PR TITLE
[PATCH] Lock screen on suspend

### DIFF
--- a/src/gs-listener-dbus.h
+++ b/src/gs-listener-dbus.h
@@ -45,6 +45,7 @@ typedef struct
         GObjectClass       parent_class;
 
         void            (* lock)                     (GSListener *listener);
+        void            (* config_lock)              (GSListener *listener);
         void            (* quit)                     (GSListener *listener);
         void            (* simulate_user_activity)   (GSListener *listener);
         gboolean        (* active_changed)           (GSListener *listener,

--- a/src/gs-monitor.c
+++ b/src/gs-monitor.c
@@ -215,6 +215,19 @@ listener_lock_cb (GSListener *listener,
 }
 
 static void
+listener_config_lock_cb (GSListener *listener,
+                         GSMonitor  *monitor)
+{
+        if (! monitor->priv->prefs->lock_disabled) {
+		gs_debug ("Locking the screen suspend");
+		gs_monitor_lock_screen (monitor);
+        } else {
+                gs_debug ("Locking disabled by the administrator");
+        }
+
+}
+
+static void
 listener_quit_cb (GSListener *listener,
                   GSMonitor  *monitor)
 {
@@ -322,6 +335,7 @@ static void
 disconnect_listener_signals (GSMonitor *monitor)
 {
         g_signal_handlers_disconnect_by_func (monitor->priv->listener, listener_lock_cb, monitor);
+        g_signal_handlers_disconnect_by_func (monitor->priv->listener, listener_config_lock_cb, monitor);
         g_signal_handlers_disconnect_by_func (monitor->priv->listener, listener_quit_cb, monitor);
         g_signal_handlers_disconnect_by_func (monitor->priv->listener, listener_active_changed_cb, monitor);
         g_signal_handlers_disconnect_by_func (monitor->priv->listener, listener_simulate_user_activity_cb, monitor);
@@ -333,6 +347,8 @@ connect_listener_signals (GSMonitor *monitor)
 {
         g_signal_connect (monitor->priv->listener, "lock",
                           G_CALLBACK (listener_lock_cb), monitor);
+        g_signal_connect (monitor->priv->listener, "config-lock",
+                          G_CALLBACK (listener_config_lock_cb), monitor);
         g_signal_connect (monitor->priv->listener, "quit",
                           G_CALLBACK (listener_quit_cb), monitor);
         g_signal_connect (monitor->priv->listener, "active-changed",


### PR DESCRIPTION
From f8f9beb6a3bf81240d36bfec43e5db9b102ea91e Mon Sep 17 00:00:00 2001
From: Martin Pitt <martinpitt@gnome.org>
Date: Wed, 1 May 2013 10:55:49 -0700
Subject: [PATCH] Lock screen on suspend

Listen for logind's PrepareForSleep signal, and lock the screen (if configured
to do so). This mirrors what gnome-shell's screensaver does.