### PR TITLE
fix segfault due to wrong object being destroyed

### DIFF
--- a/src/gs-lock-plug.c
+++ b/src/gs-lock-plug.c
@@ -554,7 +554,7 @@ gs_lock_plug_run (GSLockPlug *plug)
                 g_signal_handler_disconnect (plug, unmap_handler);
                 g_signal_handler_disconnect (plug, delete_handler);
                 g_signal_handler_disconnect (plug, destroy_handler);
-                g_signal_handler_disconnect (plug, keymap_handler);
+                g_signal_handler_disconnect (keymap, keymap_handler);
         }
 
         g_object_unref (plug);


### PR DESCRIPTION
This patch fixes a segfault which was the reason of an obvious
typo.  This segfault is particularly bad because it will create
a race condition by which the dialog will sometimes disappear
before telling the main screensaver program to unlock, thereby
cause the system to remain locked.