### PR TITLE
[WIP] Refresh window->priv->default_message value in update_clock of file gs-window-x11.c

### DIFF
--- a/src/gs-window-x11.c
+++ b/src/gs-window-x11.c
@@ -2372,6 +2372,11 @@ update_clock (GSWindow *window)
                                       window->priv->away_message, user_name);
             g_free (user_name);
         } else {
+            // Add steps to refresh local copy of default message from gsettings 
+            gchar *unesc = g_settings_get_string(window->priv->settings, "default-message");
+            window->priv->default_message = g_markup_escape_text (unesc, -1);
+            g_free (unesc);
+            
             markup = g_strdup_printf ("%s\n\n<b><span font_desc=\"%s\" foreground=\"#CCCCCC\">%s</span></b>",
                                       gnome_wall_clock_get_clock (window->priv->clock_tracker),
                                       window->priv->font_message,


### PR DESCRIPTION
Title:Refresh window->priv->default_message value in update_clock of file gs-window-x11.c
Background:  A user may enable programs that modify the gsettings to change the default message.  If this occurs while the screen saver is running the changes will not be displayed since the defualt message
is only read during init.  

Changed the gs-window-x11.c  function update_clock() by adding commands to refresh the value window->priv->default_message.  This allows populating window->priv->default_message by fortune or twitter programs.