### PR TITLE
Migrate away from gnome-common deprecated vars and macros

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,21 +1,40 @@
-#!/bin/bash
+#!/bin/sh
 # Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
+olddir=$(pwd)
 
-PKG_NAME="cinnamon-screensaver"
+cd $srcdir
 
-(test -f $srcdir/configure.ac \
-  && test -d $srcdir/src) || {
-    echo -n "**Error**: Directory"\`$srcdir\'" does not look like the"
-    echo " top-level cinnamon-screensaver directory"
+(test -f configure.ac) || {
+    echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
     exit 1
 }
 
-which gnome-autogen.sh || {
-    echo "You need to install gnome-common from GNOME Git (or from"
-    echo "your OS vendor's package manager)."
-    exit 1
-}
-USE_GNOME2_MACROS=1 USE_COMMON_DOC_BUILD=yes . gnome-autogen.sh
+# shellcheck disable=SC2016
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
+
+if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+    echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
+    echo "*** If you wish to pass any to it, please specify them on the" >&2
+    echo "*** '$0' command line." >&2
+    echo "" >&2
+fi
+
+aclocal --install || exit 1
+glib-gettextize --force --copy || exit 1
+gtkdocize --copy || exit 1
+intltoolize --force --copy --automake || exit 1
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+if [ "$NOCONFIGURE" = "" ]; then
+    $srcdir/configure "$@" || exit 1
+
+    if [ "$1" = "--help" ]; then exit 0 else
+        echo "Now type 'make' to compile $PKG_NAME" || exit 1
+    fi
+else
+    echo "Skipping configure process."
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,11 @@ AC_INIT([cinnamon-screensaver],
         [3.0.1],
         [https://github.com/linuxmint/cinnamon-screensaver/issues])
 
+AC_CONFIG_MACRO_DIR([m4])
+AC_SUBST([ACLOCAL_AMFLAGS], ["-I $ac_macro_dir \${ACLOCAL_FLAGS}"])
+
+AX_IS_RELEASE([git-directory])
+
 AC_CONFIG_SRCDIR(src/cinnamon-screensaver.c)
 
 AM_INIT_AUTOMAKE([1.10 no-dist-gzip dist-xz tar-ustar])
@@ -87,7 +92,7 @@ SAVER_LIBS="$ALL_X_LIBS"
 
 AC_PATH_PROG(GLIB_GENMARSHAL, glib-genmarshal)
 
-GNOME_COMPILE_WARNINGS(yes)
+AX_COMPILER_FLAGS([WARN_CFLAGS],[WARN_LDFLAGS])
 
 # Optional dependencies for the theme engines
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,7 +5,7 @@ NULL =
 
 saverdir = $(libexecdir)/cinnamon-screensaver
 
-INCLUDES =							\
+AM_CPPFLAGS =							\
 	-I.							\
 	-I$(srcdir)						\
 	$(CINNAMON_SCREENSAVER_CFLAGS)				\
@@ -20,7 +20,7 @@ INCLUDES =							\
 	-DSYSCONFDIR=\""$(sysconfdir)"\" 			\
 	-DGNOMELOCALEDIR=\""$(datadir)/locale"\"		\
 	-DSAVERDIR=\""$(saverdir)"\"				\
-	-DGTKBUILDERDIR=\"$(pkgdatadir)\"				\
+	-DGTKBUILDERDIR=\"$(pkgdatadir)\"			\
 	-DPAM_SERVICE_NAME=\""cinnamon-screensaver"\"		\
 	$(WARN_CFLAGS)						\
 	$(AUTH_CFLAGS)						\
@@ -203,7 +203,7 @@ cinnamon_screensaver_LDADD =		\
 	$(LOGIND_LIBS)                 \
 	$(NULL)
 
-cinnamon_screensaver_LDFLAGS = -export-dynamic
+cinnamon_screensaver_LDFLAGS = $(WARN_LDFLAGS) -export-dynamic
 
 EXTRA_DIST =				\
 	debug-screensaver.sh		\


### PR DESCRIPTION
gnome-common is deprecating some vars and macros, listed here:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=829932

This change follows the gnome recommendations from:
https://wiki.gnome.org/Projects/GnomeCommon/Migration