### PR TITLE
utils.py: handle error raised by non-zero return status

### DIFF
--- a/src/util/utils.py
+++ b/src/util/utils.py
@@ -65,7 +65,12 @@ def user_can_lock():
     return True
 
 def process_is_running(name):
-    res = subprocess.check_output(["pidof", name])
+    res = ""
+
+    try:
+        res = subprocess.check_output(["pidof", name])
+    except subprocess.CalledProcessError:
+        pass
 
     return res != ""
 


### PR DESCRIPTION
On my system, pidof exits with status 1 when the process doesn't exist. This causes a subprocess.CalledProcessError exception to be raised. I'm not sure if this is the case everywhere, though, so I've kept the existing check logic rather than returning False in the except block and True outside