### PR TITLE
utils.py: add back alternate display manager support for user switching

### DIFF
--- a/src/util/utils.py
+++ b/src/util/utils.py
@@ -89,6 +89,21 @@ def do_user_switch():
         app = Gio.AppInfo.create_from_commandline(command, "gdmflexiserver", 0)
         if app:
             app.launch(None, ctx)
+    elif os.getenv("XDG_SEAT_PATH") is not None:
+        try:
+            bus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+            bus.call_sync("org.freedesktop.DisplayManager",
+                          os.getenv("XDG_SEAT_PATH"),
+                          "org.freedesktop.DisplayManager.Seat",
+                          "SwitchToGreeter",
+                          None,
+                          None,
+                          Gio.DBusCallFlags.NONE,
+                          -1,
+                          None)
+
+        except GLib.Error as err:
+            print("Switch user failed: " + err.message)
 
 def session_is_cinnamon():
     if "cinnamon" in GLib.getenv("DESKTOP_SESSION"):


### PR DESCRIPTION
Adds back the code for activating the display manager greeter through dbus. It is based on this pre-rewrite code:

https://github.com/linuxmint/cinnamon-screensaver/blob/7a50f015fb3a984859770ca0d51ed52eb4ead417/src/gs-lock-plug.c#L208