### PR TITLE
Cinnamon screensaver gnome common finish migration

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -23,7 +23,6 @@ if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
 fi
 
 aclocal --install || exit 1
-glib-gettextize --force --copy || exit 1
 intltoolize --force --copy --automake || exit 1
 autoreconf --verbose --force --install || exit 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -10,12 +10,15 @@ PKG_PROG_PKG_CONFIG([0.26])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([ACLOCAL_AMFLAGS], ["-I $ac_macro_dir \${ACLOCAL_FLAGS}"])
 
-## AX_IS_RELEASE([git-directory])
+m4_ifdef([AX_IS_RELEASE], [AX_IS_RELEASE([always])])
 
 AC_CONFIG_SRCDIR(src/cinnamon-screensaver-main.py)
 
 AM_INIT_AUTOMAKE([1.7 no-dist-gzip dist-xz])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+
+m4_ifdef([AX_COMPILER_FLAGS],
+         [AX_COMPILER_FLAGS([WARN_CFLAGS],[WARN_LDFLAGS])])
 
 LT_INIT([disable-static])
 

--- a/debian/control
+++ b/debian/control
@@ -2,11 +2,11 @@ Source: cinnamon-screensaver
 Section: x11
 Priority: optional
 Maintainer: Linux Mint <root@linuxmint.com>
-Build-Depends: debhelper (>= 9),
+Build-Depends: autoconf-archive,
+               debhelper (>= 9),
                devscripts,
                dh-autoreconf,
                dh-python,
-               gnome-common,
                librsvg2-bin,
                python-rsvg,
                libglib2.0-dev,


### PR DESCRIPTION
Making the AX_ macros optional and finally dropping gnome-common build dependency, replacing it with autoconf-archive.
