### PR TITLE
Declare GdkX11.

### DIFF
--- a/src/cinnamon-screensaver-main.py
+++ b/src/cinnamon-screensaver-main.py
@@ -2,6 +2,7 @@
 
 import gi
 gi.require_version('Gtk', '3.0')
+gi.require_version('GdkX11', '3.0')
 
 from gi.repository import Gtk, Gdk
 import signal


### PR DESCRIPTION
This fixed a warning
`sys:1: PyGIWarning: GdkX11 was imported without specifying a version first.Use gi.require_version('GdkX11', '3.0') before import to ensure that the right version gets loaded.
`