### PR TITLE
AuthClient: Check for pam helper in subdirectory

### DIFF
--- a/src/pamhelper/authClient.py
+++ b/src/pamhelper/authClient.py
@@ -37,7 +37,7 @@ class AuthClient(GObject.Object):
         try:
             helper_path = None
             architecture = platform.machine()
-            paths = ["/usr/lib"]
+            paths = ["/usr/lib", "/usr/lib/cinnamon-screensaver"]
 
             # On x86 archs, iterate through multiple paths
             # For instance, on a Mint i686 box, the path is actually /usr/lib/i386-linux-gnu


### PR DESCRIPTION
Fixes antergos/antergos-packages#148