### PR TITLE
Add /usr/lib/misc/xscreensaver/ to the search directories list

### DIFF
--- a/screensavers/xscreensaver@cinnamon.org/main
+++ b/screensavers/xscreensaver@cinnamon.org/main
@@ -51,6 +51,7 @@ class XScreensaverPlugin:
         self.plug.disconnect(self.plug.draw_id)
 
         directories = ["/usr/lib/xscreensaver/",
+                       "/usr/lib/misc/xscreensaver/",
                        "/usr/libexec/xscreensaver/",
                        "/usr/local/lib/xscreensaver/",
                        "/usr/local/libexec/xscreensaver/"]


### PR DESCRIPTION
Fairly self explanatory. Gentoo installs xscreensaver hacks into /usr/lib/misc/xscreensaver/.