### PR TITLE
unlock.py : gsettings key "org.cinnamon.desktop.lockdown" "disable-user-switching" consideration

### DIFF
--- a/src/unlock.py
+++ b/src/unlock.py
@@ -3,7 +3,7 @@
 
 import gi
 
-from gi.repository import Gtk, Gdk, GObject, CScreensaver
+from gi.repository import Gtk, Gdk, GObject, CScreensaver, Gio
 import traceback
 
 
@@ -39,6 +39,9 @@ class UnlockDialog(BaseWindow):
 
     def __init__(self):
         super(UnlockDialog, self).__init__()
+        settings = Gio.Settings.new("org.cinnamon.desktop.lockdown")
+        isSwitchUserDisabled = settings.get_boolean("disable-user-switching")
+
 
         self.set_halign(Gtk.Align.CENTER)
         self.set_valign(Gtk.Align.CENTER)
@@ -94,18 +97,23 @@ class UnlockDialog(BaseWindow):
 
         button_box.pack_start(self.auth_unlock_button, False, False, 4)
 
-        self.auth_switch_button = TransparentButton("screensaver-switch-users-symbolic", Gtk.IconSize.LARGE_TOOLBAR)
-        self.auth_switch_button.set_tooltip_text(_("Switch User"))
+        if not isSwitchUserDisabled:
+            self.auth_switch_button = TransparentButton("screensaver-switch-users-symbolic", Gtk.IconSize.LARGE_TOOLBAR)
+            self.auth_switch_button.set_tooltip_text(_("Switch User"))
 
-        trackers.con_tracker_get().connect(self.auth_switch_button,
-                                           "clicked",
-                                           self.on_switch_user_clicked)
+            trackers.con_tracker_get().connect(self.auth_switch_button,
+                                               "clicked",
+                                               self.on_switch_user_clicked)
 
-        button_box.pack_start(self.auth_switch_button, False, False, 4)
+            button_box.pack_start(self.auth_switch_button, False, False, 4)
 
-        status.focusWidgets = [self.password_entry,
-                               self.auth_unlock_button,
-                               self.auth_switch_button]
+
+            status.focusWidgets = [self.password_entry,
+                                   self.auth_unlock_button,
+                                   self.auth_switch_button]
+        else:
+             status.focusWidgets = [self.password_entry,
+                                   self.auth_unlock_button]
 
         vbox_messages = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
 
@@ -314,4 +322,3 @@ class UnlockDialog(BaseWindow):
         Updates the name label to the current real_name.
         """
         self.realname_label.set_text(self.real_name)
-


### PR DESCRIPTION
related to this feature request.
#6136
I change the code for this applet just to remove the "switch user" option when the gsettings key "org.cinnamon.desktop.lockdown" "disable-user-switching" is true. I need it in Linux Mint 18.3 so I change it in this version.
Sorry for my english and maybe the code could be "cleaner" ?