### PR TITLE
Remove border-image from the password entry

### DIFF
--- a/src/cinnamon-screensaver-gtk3.14.css
+++ b/src/cinnamon-screensaver-gtk3.14.css
@@ -89,6 +89,7 @@
     color: white;
     background-image: none;
     background-color: transparent;
+    border-image: none;
     border-width: 1px;
     padding: 5px 10px 5px 5px;
 }

--- a/src/cinnamon-screensaver-gtk3.18.css
+++ b/src/cinnamon-screensaver-gtk3.18.css
@@ -88,6 +88,7 @@
     color: white;
     background-image: none;
     background-color: transparent;
+    border-image: none;
     border-width: 1px;
     padding: 5px 10px 5px 5px;
 }

--- a/src/cinnamon-screensaver-gtk3.20.css
+++ b/src/cinnamon-screensaver-gtk3.20.css
@@ -70,6 +70,7 @@
     color: white;
     background-image: none;
     background-color: transparent;
+    border-image: none;
     border-width: 1px;
     box-shadow: none;
 }


### PR DESCRIPTION
Some themes use it and it looks bad. For example Vertex.