### PR TITLE
Fall back to os.path.expanduser to find home dir.

### DIFF
--- a/src/dbusdepot/accountsServiceClient.py
+++ b/src/dbusdepot/accountsServiceClient.py
@@ -35,8 +35,11 @@ class AccountsServiceClient(GObject.Object):
 
     def get_face_path(self):
         face_path = None
+        home_path = self.service.get_home_dir()
+        if home_path is None:
+            home_path = os.path.expanduser('~')
 
-        for path in [os.path.join(self.service.get_home_dir(), ".face"),
+        for path in [os.path.join(home_path, ".face"),
                      self.service.get_icon_file()]:
             if os.path.exists(path):
                 face_path = path


### PR DESCRIPTION
The is_loaded property somehow never gets set to True on my work
computer (both for UserManager and User instances). When this occurs,
User.get_home_dir() returns None (actually the docs are highly vague on
when get_home_dir() can be expected to return None). Since os.path.join
throws if passed a NoneType, fall back to os.path.expanduser('~') if
User.get_home_dir() is None.