### PR TITLE
Add on-screen keyboard.

### DIFF
--- a/libcscreensaver/cs-screen-x11.c
+++ b/libcscreensaver/cs-screen-x11.c
@@ -175,7 +175,8 @@ apply_scale_factor (CsMonitorInfo *infos,
 #define MONITOR_HEIGHT_THRESHOLD 1000
 
 static gboolean
-get_low_res_mode (CsMonitorInfo *infos,
+get_low_res_mode (CsScreen      *screen,
+                  CsMonitorInfo *infos,
                   gint           n_infos)
 {
     gint i;
@@ -188,6 +189,9 @@ get_low_res_mode (CsMonitorInfo *infos,
         smallest_width = MIN (infos[i].rect.width, smallest_width);
         smallest_height = MIN (infos[i].rect.height, smallest_height);
     }
+
+    screen->smallest_width = smallest_width;
+    screen->smallest_height = smallest_height;
 
     if (smallest_width < MONITOR_WIDTH_THRESHOLD || smallest_height < MONITOR_HEIGHT_THRESHOLD)
     {
@@ -390,7 +394,8 @@ reload_monitor_infos (CsScreen *screen)
                         screen->n_monitor_infos,
                         gdk_screen_get_monitor_scale_factor (screen->gdk_screen, PRIMARY_MONITOR));
 
-    screen->low_res = get_low_res_mode (screen->monitor_infos,
+    screen->low_res = get_low_res_mode (screen,
+                                        screen->monitor_infos,
                                         screen->n_monitor_infos);
 
     g_assert (screen->n_monitor_infos > 0);
@@ -684,6 +689,35 @@ cs_screen_get_low_res_mode (CsScreen *screen)
     g_return_val_if_fail (CS_IS_SCREEN (screen), FALSE);
 
     return screen->low_res;
+}
+
+/**
+ * cs_screen_get_smallest_monitor_sizes:
+ * @screen: a #CsScreen
+ * @width: (out): width of the smallest monitor
+ * @height: (out): height of the smallest monitor
+ *
+ * Gets whether or not one of our monitors falls below the low res threshold (1200 wide).
+ * This lets us display certain things at smaller sizes to prevent truncating of images, etc.
+ *
+ * Returns: Whether or not to use low res mode.
+ */
+void
+cs_screen_get_smallest_monitor_sizes (CsScreen *screen,
+                                      gint     *width,
+                                      gint     *height)
+{
+    g_return_if_fail (CS_IS_SCREEN (screen));
+
+    if (width != NULL)
+    {
+        *width = screen->smallest_width;
+    }
+
+    if (height != NULL)
+    {
+        *height = screen->smallest_height;
+    }
 }
 
 /**

--- a/libcscreensaver/cs-screen.h
+++ b/libcscreensaver/cs-screen.h
@@ -42,6 +42,8 @@ typedef struct
     gulong screen_size_changed_id;
 
     gboolean low_res;
+    gint smallest_width;
+    gint smallest_height;
 } CsScreen;
 
 typedef struct
@@ -67,6 +69,10 @@ gint                         cs_screen_get_n_monitors (CsScreen *screen);
 gint                         cs_screen_get_mouse_monitor (CsScreen *screen);
 
 gboolean                     cs_screen_get_low_res_mode (CsScreen *screen);
+
+void                         cs_screen_get_smallest_monitor_sizes (CsScreen *screen,
+                                                                   gint     *width,
+                                                                   gint     *height);
 
 void                         cs_screen_reset_screensaver (void);
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,6 +19,7 @@ app_PYTHON = \
         infoPanel.py \
         manager.py \
         monitorView.py \
+        osk.py \
         passwordEntry.py \
         playerControl.py \
         service.py \

--- a/src/cinnamon-screensaver-gtk3.20.css
+++ b/src/cinnamon-screensaver-gtk3.20.css
@@ -193,3 +193,60 @@
     background-color: transparent;
     background-image: none;
 }
+
+.csstage .osk-button {
+    -gtk-icon-style: requested;
+    border-color: alpha(white, .2);
+    border-image: none;
+    box-shadow: none;
+    background-image: none;
+    background-color: transparent;
+    border-radius: 4px;
+    -gtk-outline-radius: 4px;
+    outline-color: transparent;
+    color: alpha(white, .7);
+    border-width: 1px;
+    padding: 4px;
+}
+
+.csstage .osk-button image {
+    color: alpha(white, .7);
+}
+
+.csstage .osk-button:disabled image {
+    color: #333333;
+}
+
+.csstage .osk-button:focus {
+    background-color: alpha(grey, .3);
+    border-color: @theme_selected_bg_color;
+    box-shadow: 1px 1px alpha(white, 0.1);
+}
+
+.csstage .osk-button:hover {
+    border-color: alpha(white, .2);
+    background-color: alpha(grey, .2);
+    box-shadow: 1px 1px alpha(white, 0.1);
+}
+
+.csstage .osk-button:hover:focus {
+    border-color: @theme_selected_bg_color;
+    background-color: alpha(grey, .4);
+    box-shadow: 1px 1px alpha(white, 0.1);
+}
+
+.csstage .osk-button:active {
+    border-color: @theme_selected_bg_color;
+    background-color: alpha(grey, .5);
+    box-shadow: 1px 1px alpha(white, 0.1);
+}
+
+.csstage .osk-button:active:focus {
+    border-color: @theme_selected_bg_color;
+    background-color: alpha(grey, .55);
+    box-shadow: 1px 1px alpha(white, 0.1);
+}
+
+.csstage .osk-popover {
+    background-color: black;
+}

--- a/src/osk.py
+++ b/src/osk.py
@@ -1,0 +1,285 @@
+#!/usr/bin/python3
+# coding: utf-8
+
+import gi
+gi.require_version('Caribou', '1.0')
+
+from gi.repository import Gtk, Gdk, GObject, Caribou, Gio, GLib
+
+import status
+from util import utils, trackers, settings
+from widgets.transparentButton import TransparentButton
+from baseWindow import BaseWindow
+
+LARGEST_OSK_WIDTH = 1200
+LARGEST_OSK_HEIGHT = 360
+DEFAULT_PADDING = 2
+
+class ExtendedKey(Gtk.Button):
+    def __init__(self, label, xkey):
+        super(ExtendedKey, self).__init__(label)
+        self.get_style_context().add_class("osk-button")
+
+        self._key = xkey
+
+        self.connect("button-press-event", lambda widget, event: self._key.press())
+        self.connect("button-release-event", lambda widget, event: self._key.release())
+
+    def update_sizes(self, width, height):
+        real_width = width * self._key.props.width
+
+        self.set_size_request(real_width, height)
+
+class Key(Gtk.Button):
+    def __init__(self, key):
+        super(Key, self).__init__()
+
+        self.get_style_context().add_class("osk-button")
+
+        self._key = key
+        self.checked = False
+        self._extended_keys = key.get_extended_keys()
+        self._extended_keyboard = None
+        self._grabbed = False
+        self._eventCaptureId = 0
+
+        self.set_label(self._key.props.label)
+
+        self._popup = None
+        self._popover_box = None
+
+        if self._extended_keys:
+            self._key.connect("notify::show-subkeys", self._on_show_subkeys_changed)
+            self._popup = Gtk.Popover(relative_to=self)
+            self._popup.get_style_context().add_class("osk-popover")
+            self.get_extended_keys()
+
+        self.connect("button-press-event", self.button_press_event)
+        self.connect("button-release-event", self.button_release_event)
+
+        if self._key.props.name in ("Control_L", "Alt_L"):
+            self.model_press_handler = self._key.connect("key-pressed", self._model_key_pressed)
+            self.model_release_handler = self._key.connect("key-released", self._model_key_released)
+
+    def update_sizes(self, width, height):
+        # The virtual key width is a multiplier based on the default key width.
+        # Keys such as the spacebar use this to become proportionally wider than
+        # other keys.
+        real_width = width * self._key.props.width
+
+        self.set_size_request(real_width, height)
+
+        if self._popover_box:
+            for child in self._popover_box.get_children():
+                child.update_sizes(width, height)
+
+    def _model_key_pressed(self, key, data=None):
+        print("pressed model")
+
+    def _model_key_released(self, key, data=None):
+        print("released model")
+
+    def button_press_event(self, widget, event, data=None):
+        # Pressing buttons quickly can be recognized as a double- or triple-click, ignore
+        # when that happens.  Extended keys should only appear on a click-hold.
+
+        if event.type in (Gdk.EventType._2BUTTON_PRESS, Gdk.EventType._3BUTTON_PRESS):
+            return Gdk.EVENT_PROPAGATE
+
+        self._key.press()
+
+        return Gdk.EVENT_PROPAGATE
+
+    def button_release_event(self, widget, event, data=None):
+        self._key.release()
+
+        return Gdk.EVENT_PROPAGATE
+
+    def get_uni_char(self, key):
+        keyval = key.props.keyval
+        unichar = Gdk.keyval_to_unicode(keyval)
+
+        if unichar:
+            return chr(unichar)
+        else:
+            return key.props.name
+
+    def get_extended_keys(self):
+        self._popover_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, margin=6)
+
+        for xkey in self._extended_keys:
+            label = self.get_uni_char(xkey)
+
+            key = ExtendedKey(label, xkey)
+            self._popover_box.pack_start(key, False, False, 2)
+
+            self._popover_box.show_all()
+
+        self._popup.add(self._popover_box)
+
+    def _on_show_subkeys_changed(self, key, pspec, data=None):
+        if self._key.props.show_subkeys:
+            self._popup.popup()
+        else:
+            self._popup.popdown()
+
+
+class OnScreenKeyboard(BaseWindow):
+    """
+    An on-screen keyboard that can be used to input the password in the lockscreen.  If
+    accessibility doesn't have the osk enabled, we don't construct the keyboard initially,
+    to save footprint.  If needed, the keyboard button can be pressed to display the keyboard
+    on demand, and it gets constructed then.
+    """
+    def __init__(self):
+        super(OnScreenKeyboard, self).__init__()
+
+        self.set_halign(Gtk.Align.CENTER)
+        self.set_valign(Gtk.Align.END)
+
+        self.props.margin = 30
+
+        smallest_width, smallest_height = status.screen.get_smallest_monitor_sizes()
+
+        self.max_width = min(smallest_width, LARGEST_OSK_WIDTH) - 60
+        self.max_height = min(smallest_height / 3, LARGEST_OSK_HEIGHT) - 60 
+        # print(self.max_width, self.max_height)
+
+        self._group_stack = None
+
+        self.base_stack = Gtk.Stack()
+        self.add(self.base_stack)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL,
+                      halign=Gtk.Align.CENTER,
+                      valign=Gtk.Align.END)
+
+        activate_button = TransparentButton("input-keyboard-symbolic", Gtk.IconSize.LARGE_TOOLBAR)
+        activate_button.connect("clicked", self.on_activate_button_clicked)
+
+        box.pack_start(activate_button, False, False, 0)
+        box.show_all()
+
+        self.base_stack.add_named(box, "disabled")
+        self.base_stack.show_all()
+
+        if settings.get_osk_a11y_active():
+            self.build_and_show_keyboard()
+
+    def on_activate_button_clicked(self, button, data=None):
+        self.build_and_show_keyboard()
+
+    def on_caribou_button_clicked(self, button, data=None):
+        self.base_stack.set_visible_child_name("disabled")
+
+    def build_and_show_keyboard(self):
+        if not self._group_stack:
+            self._keyboard = Caribou.KeyboardModel(keyboard_type=settings.get_osk_type())
+
+            self._group_stack = Gtk.Stack(visible=True)
+
+            self._groups = {}
+
+            self._add_keys()
+            self._group_stack.show_all()
+
+            self.base_stack.add_named(self._group_stack, "enabled")
+
+        self.base_stack.set_visible_child_name("enabled")
+
+    def _add_keys(self):
+        groups = self._keyboard.get_groups()
+
+        size_group = Gtk.SizeGroup(mode=Gtk.SizeGroupMode.HORIZONTAL)
+
+        for group_name in groups:
+            group = self._keyboard.get_group(group_name)
+
+            group.connect("notify::active-level", self._on_level_changed)
+
+            layers = {}
+            levels = group.get_levels()
+
+            for level_name in levels:
+                level = group.get_level(level_name)
+
+                box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+                size_group.add_widget(box)
+
+                self._load_rows(level, box)
+
+                layers[level_name] = box
+
+                box.show_all()
+                self._group_stack.add_named(box, "%s::%s" % (group_name, level_name))
+
+            self._groups[group_name] = layers
+
+        self.set_active_layer()
+
+    def _on_level_changed(self, object, pspec, data=None):
+        self.set_active_layer()
+
+    def _load_rows(self, level, box):
+        rows = level.get_rows()
+
+        row_height = self.max_height / len(rows)
+
+        for row in rows:
+            self._add_rows(row.get_columns(), box, row_height)
+
+    def _add_rows(self, keys, box, row_height):
+        num_keys = 0
+        row_children = []
+
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+
+        for key in keys:
+            right_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+            left_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+            children = key.get_children()
+
+            right_box_members = []
+
+            for child in children:
+                button = Key(child)
+
+                num_keys += child.props.width
+                row_children.append(button)
+
+                if child.props.align == "right":
+                    right_box_members.append(button)
+                else:
+                    left_box.pack_start(button, False, False, DEFAULT_PADDING)
+
+            if right_box_members:
+                right_box_members.reverse()
+
+                for member in right_box_members:
+                    right_box.pack_end(member, False, False, DEFAULT_PADDING)
+
+                if child.props.name == "Caribou_Prefs":
+                    button.connect("clicked", self.on_caribou_button_clicked)
+
+            if left_box.get_children():
+                row.pack_start(left_box, True, True, 0)
+
+            if right_box.get_children():
+                row.pack_end(right_box, True, True, 0)
+
+        key_width = (self.max_width / (num_keys )) - (DEFAULT_PADDING * 2)
+        key_height = row_height - (DEFAULT_PADDING * 2)
+
+        for child in row_children:
+            child.update_sizes(key_width, key_height)
+
+        box.pack_start(row, False, False, DEFAULT_PADDING)
+
+    def set_active_layer(self):
+        active_group_name = self._keyboard.props.active_group
+
+        active_group = self._keyboard.get_group(active_group_name)
+        active_level = active_group.props.active_level
+
+        layers = self._groups[active_group_name]
+        self._group_stack.set_visible_child_name("%s::%s" % (active_group_name, active_level))

--- a/src/tests/test-osk
+++ b/src/tests/test-osk
@@ -1,0 +1,41 @@
+#!/usr/bin/python3
+
+import sys
+import signal
+import gettext
+
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('CScreensaver', '1.0')
+
+sys.path.append("/usr/share/cinnamon-screensaver")
+gettext.install("cinnamon-screensaver", "/usr/share/locale")
+
+from gi.repository import Gtk, CScreensaver
+
+from osk import OnScreenKeyboard
+import status
+
+signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+class Main:
+    def __init__(self):
+        status.screen = CScreensaver.Screen.new(True)
+
+        win = Gtk.Window()
+
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        win.add(box)
+        win.get_style_context().add_class("csstage")
+
+        self.osk = OnScreenKeyboard()
+        box.pack_start(self.osk, True, True, 2)
+        box.show_all()
+
+        win.connect("delete-event", lambda w, e: Gtk.main_quit())
+        win.present()
+
+        Gtk.main()
+
+if __name__ == "__main__":
+    main = Main()

--- a/src/util/settings.py
+++ b/src/util/settings.py
@@ -41,6 +41,14 @@ KBD_LAYOUT_SHOW_FLAGS = "keyboard-layout-show-flags"
 KBD_LAYOUT_USE_CAPS = "keyboard-layout-use-upper"
 KBD_LAYOUT_PREFER_VARIANT = "keyboard-layout-prefer-variant-names"
 
+osk_settings = Gio.Settings(schema_id="org.cinnamon.keyboard")
+OSK_TYPE = "keyboard-type"
+OSK_SIZE = "keyboard-size"
+OSK_ACTIVATION = "activation-mode"
+
+a11y_settings = Gio.Settings(schema_id="org.cinnamon.desktop.a11y.applications")
+OSK_A11Y_ENABLED = "screen-keyboard-enabled"
+
 # Every setting has a getter (and setter, rarely).  This is mainly for
 # organizational purposes and cleanliness - it's easier to read in the
 # main code if you see "settings.get_default_away_message()" than seeing
@@ -130,3 +138,9 @@ def get_show_info_panel():
 
 def get_allow_floating():
     return ss_settings.get_boolean(FLOATING_WIDGETS)
+
+def get_osk_type():
+    return osk_settings.get_string(OSK_TYPE)
+
+def get_osk_a11y_active():
+    return a11y_settings.get_boolean(OSK_A11Y_ENABLED)


### PR DESCRIPTION
Uses libcaribou, which is already needed by cinnamon.  I probably will depend on it here also in debian control (though that's not done yet)

![screenshot from 2018-12-16 19-38-06](https://user-images.githubusercontent.com/262776/50061099-5c682100-016a-11e9-995a-4cda947918de.png)
![screenshot from 2018-12-16 19-37-45](https://user-images.githubusercontent.com/262776/50061104-5ffba800-016a-11e9-8bb2-dfd8109d6bc7.png)
