### PR TITLE
Handle custom-screensaver-command gsettings config

### DIFF
--- a/src/cinnamon-screensaver-main.py
+++ b/src/cinnamon-screensaver-main.py
@@ -14,7 +14,7 @@ import setproctitle
 
 import config
 import status
-from util import utils
+from util import utils, settings
 
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 gettext.install("cinnamon-screensaver", "/usr/share/locale")
@@ -39,6 +39,10 @@ class Main:
         parser.add_argument('--no-daemon', dest='no_daemon', action='store_true',
                             help="Deprecated: left for compatibility only - we never become a daemon")
         args = parser.parse_args()
+
+        if settings.get_custom_screensaver() != '':
+            print("custom screensaver selected, exiting cinnamon-screensaver.")
+            quit()
 
         if args.version:
             print("cinnamon-screensaver %s" % (config.VERSION))

--- a/src/util/settings.py
+++ b/src/util/settings.py
@@ -15,6 +15,7 @@ bg_settings = Gio.Settings(schema_id="org.cinnamon.desktop.background")
 ss_settings = Gio.Settings(schema_id="org.cinnamon.desktop.screensaver")
 DEFAULT_MESSAGE_KEY = "default-message"
 SCREENSAVER_NAME_KEY = "screensaver-name"
+CUSTOM_SCREENSAVER_KEY = "custom-screensaver-command"
 USER_SWITCH_ENABLED_KEY = "user-switch-enabled"
 IDLE_ACTIVATE_KEY = "idle-activation-enabled"
 LOCK_ENABLED_KEY = "lock-enabled"
@@ -65,6 +66,11 @@ def get_default_away_message():
     msg = ss_settings.get_string(DEFAULT_MESSAGE_KEY)
 
     return _check_string(msg)
+
+def get_custom_screensaver():
+    cmd = ss_settings.get_string(CUSTOM_SCREENSAVER_KEY)
+
+    return _check_string(cmd)
 
 def get_user_switch_enabled():
     return ss_settings.get_boolean(USER_SWITCH_ENABLED_KEY)


### PR DESCRIPTION
If a custom screensaver is configured, we abort the starting
cinnamon-screensaver daemon process to avoid two screensavers from
conflicting each other.

In cinnamon-screensaver-command, we start the custom screensaver command
if one is configured.

This patch needs accompanying patches in cinnamon-desktop and cinnamon-settings-daemon.

https://github.com/linuxmint/cinnamon-desktop/pull/134
https://github.com/linuxmint/cinnamon-settings-daemon/pull/270