### PR TITLE
[Next] [WIP] Display PAM authentication client info

### DIFF
--- a/src/pamhelper/authClient.py
+++ b/src/pamhelper/authClient.py
@@ -20,7 +20,8 @@ class AuthClient(GObject.Object):
         'auth-failure': (GObject.SignalFlags.RUN_LAST, None, ()),
         'auth-cancel': (GObject.SignalFlags.RUN_LAST, None, ()),
         'auth-busy': (GObject.SignalFlags.RUN_LAST, None, (bool,)),
-        'auth-prompt': (GObject.SignalFlags.RUN_LAST, None, (str,))
+        'auth-prompt': (GObject.SignalFlags.RUN_LAST, None, (str,)),
+        'auth-info': (GObject.SignalFlags.RUN_LAST, None, (str,))
     }
 
     def __init__(self):
@@ -174,6 +175,10 @@ class AuthClient(GObject.Object):
                     if "CS_PAM_AUTH_SET_PROMPT" in output:
                         prompt = re.search('(?<=CS_PAM_AUTH_SET_PROMPT_)(.*)(?=_)', output).group(0)
                         self.emit_idle_auth_prompt(prompt)
+                    if "CS_PAM_AUTH_SET_INFO" in output:
+                        info = re.search('(?<=CS_PAM_AUTH_SET_INFO_)(.*)(?=_)', output).group(0)
+                        self.emit_auth_info(info)
+
         if not finished:
             pipe.read_bytes_async(1024, GLib.PRIORITY_DEFAULT, None, self.message_from_child)
 
@@ -201,3 +206,8 @@ class AuthClient(GObject.Object):
         if status.Debug:
             print("authClient: idle add auth-prompt")
         GObject.idle_add(self.emit, "auth-prompt", prompt)
+
+    def emit_auth_info(self, info):
+        if status.Debug:
+            print("authClient: auth-info")
+        GObject.idle_add(self.emit, "auth-info", info)

--- a/src/pamhelper/cinnamon-screensaver-pam-helper.c
+++ b/src/pamhelper/cinnamon-screensaver-pam-helper.c
@@ -63,6 +63,7 @@ static GOptionEntry entries [] = {
 #define CS_PAM_AUTH_BUSY_FALSE "CS_PAM_AUTH_BUSY_FALSE\n"
 
 #define CS_PAM_AUTH_SET_PROMPT_ "CS_PAM_AUTH_SET_PROMPT_"
+#define CS_PAM_AUTH_SET_INFO_ "CS_PAM_AUTH_SET_INFO_"
 
 #define CS_PAM_AUTH_REQUEST_SUBPROCESS_EXIT "CS_PAM_AUTH_REQUEST_SUBPROCESS_EXIT"
 
@@ -129,6 +130,13 @@ static void
 send_prompt (const gchar *msg)
 {
     printf (CS_PAM_AUTH_SET_PROMPT_ "%s_\n", msg);
+    fflush (stdout);
+}
+
+static void
+send_info (const gchar *msg)
+{
+    printf (CS_PAM_AUTH_SET_INFO_ "%s_\n", msg);
     fflush (stdout);
 }
 
@@ -200,6 +208,10 @@ auth_message_handler (CsAuthMessageStyle style,
         case CS_AUTH_MESSAGE_ERROR_MSG:
             break;
         case CS_AUTH_MESSAGE_TEXT_INFO:
+            if (msg != NULL)
+            {
+              send_info(msg);
+            }
             break;
         default:
             g_assert_not_reached ();

--- a/src/unlock.py
+++ b/src/unlock.py
@@ -47,6 +47,7 @@ class UnlockDialog(BaseWindow):
 
         self.real_name = None
         self.user_name = None
+        self.auth_info = None
 
         self.bounce_rect = None
         self.bounce_count = 0
@@ -67,6 +68,12 @@ class UnlockDialog(BaseWindow):
         self.realname_label.set_halign(Gtk.Align.CENTER)
 
         self.box.pack_start(self.realname_label, False, False, 10)
+
+        self.authinfo_label = Gtk.Label(None)
+        self.authinfo_label.set_alignment(0, 0.5)
+        self.authinfo_label.set_halign(Gtk.Align.CENTER)
+
+        self.box.pack_start(self.authinfo_label, False, False, 10)
 
         self.entry_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
 
@@ -160,6 +167,10 @@ class UnlockDialog(BaseWindow):
         trackers.con_tracker_get().connect(self.auth_client,
                                            "auth-prompt",
                                            self.on_authentication_prompt_changed)
+        trackers.con_tracker_get().connect(self.auth_client,
+                                           "auth-info",
+                                           self.on_authentication_info_changed)
+
 
         self.box.show_all()
 
@@ -209,6 +220,10 @@ class UnlockDialog(BaseWindow):
 
         self.password_entry.placeholder_text = prompt
         self.password_entry.set_placeholder_text(self.password_entry.placeholder_text)
+
+    def on_authentication_info_changed(self, auth_client, info):
+        self.auth_info = info
+        self.update_authinfo_label()
 
     def cancel(self):
         """
@@ -302,12 +317,20 @@ class UnlockDialog(BaseWindow):
         Clear the password entry widget.
         """
         self.password_entry.set_text("")
+        self.auth_info = ""
+        self.update_authinfo_label()
 
     def update_realname_label(self):
         """
         Updates the name label to the current real_name.
         """
         self.realname_label.set_text(self.real_name)
+
+    def update_authinfo_label(self):
+        """
+        Updates the auth info label to the current auth_info message.
+        """
+        self.authinfo_label.set_text(self.auth_info)
 
     def blink(self):
         GObject.timeout_add(75, self.on_blink_tick)


### PR DESCRIPTION
`CS_AUTH_MESSAGE_TEXT_INFO`-type output is shown on a single line under the username text, above the password input.

Trying to figure out how to take a screenshot of this...

This is especially useful when non-input PAM modules are used (for example, `fprintd` would show a message telling the user to put their finger on the scanner)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/linuxmint/cinnamon-screensaver/341)
<!-- Reviewable:end -->
