### PR TITLE
build: use datadir in define_variable for dbus_services_dir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -43,7 +43,7 @@ x11 = dependency('x11')
 xext = dependency('xext')
 xrandr = dependency('xrandr', required: false)
 m = cc.find_library('m')
-dbus_services_dir = dependency('dbus-1').get_pkgconfig_variable('session_bus_services_dir', define_variable: ['prefix', prefix])
+dbus_services_dir = dependency('dbus-1').get_pkgconfig_variable('session_bus_services_dir', define_variable: ['datadir', datadir])
 
 # check for symbols and headers
 foreach header : [


### PR DESCRIPTION
We have to use datadir to effect dbus-1.pc https://github.com/freedesktop/dbus/blob/b387bd4d2916416f1376fe9feeee61e557d571de/dbus-1.pc.in#L11