### PR TITLE
Fix error: no return statement in function

### DIFF
--- a/backup-locker/cs-backup-locker.c
+++ b/backup-locker/cs-backup-locker.c
@@ -156,6 +156,7 @@ window_grab_broken (gpointer data)
     {
         activate_backup_window (window);
     }
+    return 0; 
 }
 
 static void

--- a/backup-locker/cs-backup-locker.c
+++ b/backup-locker/cs-backup-locker.c
@@ -156,7 +156,7 @@ window_grab_broken (gpointer data)
     {
         activate_backup_window (window);
     }
-    return 0; 
+    return GDK_EVENT_PROPAGATE;
 }
 
 static void


### PR DESCRIPTION
When building with cmake-ninja, the warning popup.
```

../backup-locker/cs-backup-locker.c:159:1: error: no return statement in function returning non-void [-Werror=return-type]
  159 | }
         | ^
```

Hopefully this is the correct way to fix it.