### PR TITLE
updated trackname and albumartist to use more suitable fonts 

### DIFF
--- a/src/cinnamon-screensaver.css
+++ b/src/cinnamon-screensaver.css
@@ -174,7 +174,7 @@
 }
 
 .csstage .trackname {
-    font-family: monospace;
+    font-family: ubuntu;
     font-size: 12px;
     text-shadow: 1px 1px alpha(black, 0.8);
     background-image: none;
@@ -182,7 +182,7 @@
 }
 
 .csstage .albumartist {
-    font-family: monospace;
+    font-family: ubuntu;
     font-size: 8px;
     text-shadow: 1px 1px alpha(black, 0.8);
     background-image: none;


### PR DESCRIPTION
Ubuntu font family used. Changed to integrate better with a stock cinnamon install, should be updated to follow system font prefs in the future, but I see this as a welcome change over the monospace font, which, in my opinion shouldn't be used by default in most UI elements. 