### PR TITLE
media player: Fix async setup of player controls.

### DIFF
--- a/src/audioPanel.py
+++ b/src/audioPanel.py
@@ -5,7 +5,7 @@ from gi.repository import Gtk
 from baseWindow import BaseWindow
 from volumeControl import VolumeControl
 from playerControl import PlayerControl
-from util import utils, settings
+from util import utils, settings, trackers
 import status
 
 class AudioPanel(BaseWindow):
@@ -43,8 +43,12 @@ class AudioPanel(BaseWindow):
 
         should_show = self.player_widget.should_show()
 
-        if not self.player_widget.should_show():
-            self.disabled = True
+        trackers.con_tracker_get().connect(self.player_widget.watcher,
+                                           "players-changed",
+                                           self.update_visibility)
+
+    def update_visibility(self, watcher):
+        self.disabled = not self.player_widget.should_show()
 
     def show_panel(self):
         if not self.disabled:

--- a/src/cinnamon-screensaver-main.py
+++ b/src/cinnamon-screensaver-main.py
@@ -66,6 +66,7 @@ class Main(Gtk.Application):
 
         status.LockEnabled = not args.lock_disabled
         status.Debug = args.debug
+        status.Debug = True
         status.InteractiveDebug = args.interactive
 
         if status.Debug:


### PR DESCRIPTION
When cinnamon-screensaver ran as a daemon, the media pleyer watcher
had plenty of time to set up and identify valid players before the
screensaver would actually be used.

Now that this is an on-demand service, the watcher won't be ready
before the stage spawns, when it would normally be queried over
whether or not to show the controls.

This sets things up so the audio controls and mpris connection
can be set up at any point, and the ui will update as needed.