### PR TITLE
Prioritize Playing Audio over other players.

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -4,7 +4,20 @@ HACKING
 Cinnamon-Screensaver is normally build using dpkg. If using Linux Mint, Ubuntu,
 or any other member of the Debian family, install the `devscripts` package with
  `sudo apt-get install devscripts`.
- 
+
+Other commands I had to run to get it to build:
+  sudo apt-get install devscripts
+  sudo apt install dh-make
+  sudo apt install dh-python
+  sudo apt install gobject-introspection 
+  sudo apt install meson
+  sudo apt install cmake
+  sudo apt install build-essential libgtk-3-dev
+  sudo apt install libxdo-dev
+  sudo apt install libgirepository1.0-dev
+
+
+
 Once you have devscripts, run `debuild -us -uc` to build cinnamon-screensaver
 (or any other cinnamon package) and `sudo dpkg -i ../cinnamon-screensaver_{version}_{arch}.deb`
 to install.

--- a/src/dbusdepot/mediaPlayerWatcher.py
+++ b/src/dbusdepot/mediaPlayerWatcher.py
@@ -260,7 +260,7 @@ class MediaPlayerWatcher(GObject.Object):
 
     def get_best_player(self):
         """
-        Find the first player in our list that is either playing, or
+        Find the first player in our list that is playing, then for a that
         *can* be played.  Players that are simply loaded but don't have
         any playlist queued up should not pass these tests - we have only
         limited control from the lockscreen.
@@ -269,6 +269,7 @@ class MediaPlayerWatcher(GObject.Object):
             if client.get_playback_status() == PlaybackStatus.Playing:
                 return client
 
+        for client in self.player_clients:
             if client.get_can_play_pause() and client.get_can_control():
                 return client
 


### PR DESCRIPTION
The prioritization needs to be specifically for a playing player before settling on a random possible player.  It looks like it wanted to do this, but it needed two loops or a smarter loop.