### PR TITLE
use Gio flags instead of ints

### DIFF
--- a/src/clock.py
+++ b/src/clock.py
@@ -66,7 +66,7 @@ class ClockWidget(Floating, BaseWindow):
                                            self.on_clock_changed)
 
         tz = Gio.File.new_for_path(path="/etc/localtime")
-        self.tz_monitor = tz.monitor_file(0, None)
+        self.tz_monitor = tz.monitor_file(Gio.FileMonitorFlags.NONE, None)
 
         trackers.con_tracker_get().connect(self.tz_monitor,
                                            "changed",

--- a/src/util/utils.py
+++ b/src/util/utils.py
@@ -93,20 +93,20 @@ def do_user_switch_timeout(data=None):
         command = "%s %s" % ("mdmflexiserver", "--startnew Standard")
         ctx = Gdk.Display.get_default().get_app_launch_context()
 
-        app = Gio.AppInfo.create_from_commandline(command, "mdmflexiserver", 0)
+        app = Gio.AppInfo.create_from_commandline(command, "mdmflexiserver", Gio.AppInfoCreateFlags.NONE)
         if app:
             app.launch(None, ctx)
     elif process_is_running("gdm"):
         command = "%s %s" % ("gdmflexiserver", "--startnew Standard")
         ctx = Gdk.Display.get_default().get_app_launch_context()
 
-        app = Gio.AppInfo.create_from_commandline(command, "gdmflexiserver", 0)
+        app = Gio.AppInfo.create_from_commandline(command, "gdmflexiserver", Gio.AppInfoCreateFlags.NONE)
         if app:
             app.launch(None, ctx)
     elif process_is_running("gdm3"):
         ctx = Gdk.Display.get_default().get_app_launch_context()
 
-        app = Gio.AppInfo.create_from_commandline("gdmflexiserver", None, 0)
+        app = Gio.AppInfo.create_from_commandline("gdmflexiserver", None, Gio.AppInfoCreateFlags.NONE)
         if app:
             app.launch(None, ctx)
     elif os.getenv("XDG_SEAT_PATH") is not None:


### PR DESCRIPTION
Instead of unsung ints Gio flags should be used. This makes it easier to understand the meaning of the value.