### PR TITLE
Possibly fix account lock

### DIFF
--- a/src/unlock.py
+++ b/src/unlock.py
@@ -227,7 +227,6 @@ class UnlockDialog(BaseWindow):
         """
         Clears the auth message text if we have any.
         """
-        self.auth_client.cancel()
         self.clear_entry()
 
     def queue_key_event(self, event):


### PR DESCRIPTION
Fix some causes of #412 

Previously in #452 I thought `cancel` was misbehaving and tried to fix that, but later figured out that this is the expected behaviour. The real fix is to do no cancel.

I don't know if there is any side effect after removing this line, but it does solve the issue on my machine.
