### PR TITLE
libscreensaver: fix detection of monitor hotplug

### DIFF
--- a/libcscreensaver/cs-screen-x11.c
+++ b/libcscreensaver/cs-screen-x11.c
@@ -416,7 +416,7 @@ is_full_change (CsScreen *screen)
 {
     // Check to see if the union of monitor rects is the same size as the screen
 
-    GdkRectangle total_monitors;
+    GdkRectangle total_monitors = {0};
     gint i;
     gboolean same;
 


### PR DESCRIPTION
When hot-adding monitors (e.g. DisplayPort), I was seeing unobscured content behind the screensaver.  Debug mode revealed:

	CsScreen received 'monitors-changed' signal from GdkScreen 25675900
	Found 2 Xinerama screens on display :0
	Monitor 0 is 0,0 1920 x 1080
	Monitor 1 is 1920,0 1920 x 1200
	Cinnamon Screensaver compiled without Solaris Xinerama support
	Scale factor of 1 applied.  Monitor 0 is 0,0 1920 x 1080
	Scale factor of 1 applied.  Monitor 1 is 1920,0 1920 x 1200
	Screen rect (0,0-3840x1200) and 2 monitor rects (0,0-503284330x1200) DO NOT add up, skipping change notification cinnamon-screensaver

This could be caused by `total_monitors` rect being uninitialized; zero it.  Might fix #437.  Seems like this could fix #460, though the log therein does _not_ say "DO NOT add up".

Ref: #437
Ref: #460
Fixes: d23d1ea "Rework behavior surrounding sleep, display changes, fractional scaling."