### PR TITLE
Fix crash on invalid geometry from NVIDIA multi-monitor setups

### DIFF
--- a/libcscreensaver/cs-screen-x11.c
+++ b/libcscreensaver/cs-screen-x11.c
@@ -42,6 +42,7 @@ static gboolean debug_mode = FALSE;
 #define cs_XFree(p) do { if ((p)) XFree ((p)); } while (0)
 
 #define PRIMARY_MONITOR 0
+#define MIN_MONITOR_DIMENSION 64
 
 static gboolean
 cs_rectangle_equal (const GdkRectangle *src1,
@@ -438,25 +439,127 @@ is_full_change (CsScreen *screen)
     return same;
 }
 
+static gboolean
+has_valid_monitor_dimensions (CsScreen *screen)
+{
+    gint i;
+
+    for (i = 0; i < screen->n_monitor_infos; i++)
+    {
+        if (screen->monitor_infos[i].rect.width < MIN_MONITOR_DIMENSION ||
+            screen->monitor_infos[i].rect.height < MIN_MONITOR_DIMENSION)
+        {
+            g_printerr ("Monitor %d has invalid dimensions %dx%d (minimum %d), rejecting geometry\n",
+                         i,
+                         screen->monitor_infos[i].rect.width,
+                         screen->monitor_infos[i].rect.height,
+                         MIN_MONITOR_DIMENSION);
+            return FALSE;
+        }
+    }
+
+    if (screen->rect.width < MIN_MONITOR_DIMENSION ||
+        screen->rect.height < MIN_MONITOR_DIMENSION)
+    {
+        g_printerr ("Screen has invalid dimensions %dx%d (minimum %d), rejecting geometry\n",
+                     screen->rect.width,
+                     screen->rect.height,
+                     MIN_MONITOR_DIMENSION);
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+static gboolean
+deferred_geometry_recheck (gpointer user_data)
+{
+    CsScreen *screen = CS_SCREEN (user_data);
+
+    screen->deferred_recheck_id = 0;
+
+    DEBUG ("CsScreen deferred geometry re-check firing at %ld\n", g_get_monotonic_time () / 1000);
+
+    /* Re-read current geometry and check if it has settled to a valid state */
+    CsMonitorInfo *old_monitor_infos = screen->monitor_infos;
+    GdkRectangle old_rect = screen->rect;
+
+    reload_monitor_infos (screen);
+    reload_screen_info (screen);
+
+    if (!has_valid_monitor_dimensions (screen) || !is_full_change (screen))
+    {
+        /* Still invalid - revert again */
+        g_printerr ("Deferred re-check: geometry still invalid, keeping previous state\n");
+        g_free (screen->monitor_infos);
+        screen->monitor_infos = old_monitor_infos;
+        screen->rect = old_rect;
+        return G_SOURCE_REMOVE;
+    }
+
+    g_free (old_monitor_infos);
+
+    g_printerr ("Deferred re-check: geometry settled, emitting change signals\n");
+    g_signal_emit (screen, signals[SCREEN_MONITORS_CHANGED], 0);
+    g_signal_emit (screen, signals[SCREEN_SIZE_CHANGED], 0);
+
+    return G_SOURCE_REMOVE;
+}
+
+static void
+schedule_deferred_recheck (CsScreen *screen)
+{
+    if (screen->deferred_recheck_id > 0)
+    {
+        g_source_remove (screen->deferred_recheck_id);
+    }
+
+    screen->deferred_recheck_id = g_timeout_add (500, deferred_geometry_recheck, screen);
+}
+
 static void
 on_monitors_changed (GdkScreen *gdk_screen, gpointer user_data)
 {
     CsScreen *screen;
     CsMonitorInfo *old_monitor_infos;
+    GdkRectangle old_rect;
+    gint old_n_monitor_infos;
 
     screen = CS_SCREEN (user_data);
 
     DEBUG ("CsScreen received 'monitors-changed' signal from GdkScreen %ld\n", g_get_monotonic_time () / 1000);
     gdk_flush ();
 
+    /* Save old state for rollback */
     old_monitor_infos = screen->monitor_infos;
+    old_rect = screen->rect;
+    old_n_monitor_infos = screen->n_monitor_infos;
+
     reload_monitor_infos (screen);
-    g_free (old_monitor_infos);
     reload_screen_info (screen);
+
+    if (!has_valid_monitor_dimensions (screen))
+    {
+        /* Invalid geometry - revert to old state and schedule re-check */
+        g_printerr ("Monitors-changed: invalid geometry detected, reverting and scheduling re-check\n");
+        g_free (screen->monitor_infos);
+        screen->monitor_infos = old_monitor_infos;
+        screen->n_monitor_infos = old_n_monitor_infos;
+        screen->rect = old_rect;
+        schedule_deferred_recheck (screen);
+        return;
+    }
+
+    g_free (old_monitor_infos);
 
     if (is_full_change (screen))
     {
         g_signal_emit (screen, signals[SCREEN_MONITORS_CHANGED], 0);
+    }
+    else
+    {
+        /* Screen/monitor rects don't add up - schedule re-check */
+        schedule_deferred_recheck (screen);
     }
 }
 
@@ -465,20 +568,44 @@ on_screen_changed (GdkScreen *gdk_screen, gpointer user_data)
 {
     CsScreen *screen;
     CsMonitorInfo *old_monitor_infos;
+    GdkRectangle old_rect;
+    gint old_n_monitor_infos;
 
     screen = CS_SCREEN (user_data);
 
     DEBUG ("CsScreen received 'size-changed' signal from GdkScreen %ld\n", g_get_monotonic_time () / 1000);
     gdk_flush ();
 
+    /* Save old state for rollback */
     old_monitor_infos = screen->monitor_infos;
+    old_rect = screen->rect;
+    old_n_monitor_infos = screen->n_monitor_infos;
+
     reload_monitor_infos (screen);
-    g_free (old_monitor_infos);
     reload_screen_info (screen);
+
+    if (!has_valid_monitor_dimensions (screen))
+    {
+        /* Invalid geometry - revert to old state and schedule re-check */
+        g_printerr ("Size-changed: invalid geometry detected, reverting and scheduling re-check\n");
+        g_free (screen->monitor_infos);
+        screen->monitor_infos = old_monitor_infos;
+        screen->n_monitor_infos = old_n_monitor_infos;
+        screen->rect = old_rect;
+        schedule_deferred_recheck (screen);
+        return;
+    }
+
+    g_free (old_monitor_infos);
 
     if (is_full_change (screen))
     {
         g_signal_emit (screen, signals[SCREEN_SIZE_CHANGED], 0);
+    }
+    else
+    {
+        /* Screen/monitor rects don't add up - schedule re-check */
+        schedule_deferred_recheck (screen);
     }
 }
 
@@ -562,6 +689,12 @@ cs_screen_dispose (GObject *object)
     {
         g_signal_handler_disconnect (screen->gdk_screen, screen->composited_changed_id);
         screen->composited_changed_id = 0;
+    }
+
+    if (screen->deferred_recheck_id > 0)
+    {
+        g_source_remove (screen->deferred_recheck_id);
+        screen->deferred_recheck_id = 0;
     }
 
     DEBUG ("CsScreen dispose\n");

--- a/libcscreensaver/cs-screen.h
+++ b/libcscreensaver/cs-screen.h
@@ -45,6 +45,9 @@ typedef struct
     gboolean low_res;
     gint smallest_width;
     gint smallest_height;
+
+    /* Deferred geometry re-check after transient mismatch (e.g. NVIDIA multi-monitor) */
+    guint deferred_recheck_id;
 } CsScreen;
 
 typedef struct

--- a/src/cinnamon-screensaver-main.py
+++ b/src/cinnamon-screensaver-main.py
@@ -11,8 +11,10 @@ import signal
 import gettext
 import argparse
 import os
+import atexit
 import setproctitle
 import sys
+import traceback
 
 import config
 import status
@@ -21,6 +23,46 @@ from service import ScreensaverService
 
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 gettext.install("cinnamon-screensaver", "/usr/share/locale")
+
+
+def _excepthook(exc_type, exc_value, exc_tb):
+    """Log full tracebacks for unhandled exceptions instead of silent death."""
+    print("cinnamon-screensaver: unhandled exception:", flush=True)
+    traceback.print_exception(exc_type, exc_value, exc_tb)
+
+sys.excepthook = _excepthook
+
+
+def _cleanup_pam_helpers():
+    """Kill any orphaned cinnamon-screensaver-pam-helper child processes."""
+    try:
+        import subprocess
+        pid = os.getpid()
+        result = subprocess.run(
+            ["pgrep", "-P", str(pid), "-f", "cinnamon-screensaver-pam-helper"],
+            capture_output=True, text=True
+        )
+        for line in result.stdout.strip().split("\n"):
+            if line.strip():
+                child_pid = int(line.strip())
+                print("cinnamon-screensaver: cleaning up orphaned PAM helper pid %d" % child_pid, flush=True)
+                try:
+                    os.kill(child_pid, signal.SIGTERM)
+                except OSError:
+                    pass
+    except Exception as e:
+        print("cinnamon-screensaver: error cleaning up PAM helpers: %s" % e, flush=True)
+
+atexit.register(_cleanup_pam_helpers)
+
+
+def _sigterm_handler(signum, frame):
+    """Handle SIGTERM gracefully: clean up PAM helpers and exit."""
+    print("cinnamon-screensaver: received SIGTERM, cleaning up...", flush=True)
+    _cleanup_pam_helpers()
+    sys.exit(0)
+
+signal.signal(signal.SIGTERM, _sigterm_handler)
 
 class Main(Gtk.Application):
     """

--- a/src/stage.py
+++ b/src/stage.py
@@ -20,6 +20,8 @@ from util import utils, trackers, settings
 from util.eventHandler import EventHandler
 from util.utils import DEBUG
 
+MIN_MONITOR_DIMENSION = 64
+
 try:
     from osk import OnScreenKeyboard
 except Exception as e:
@@ -160,14 +162,52 @@ class Stage(Gtk.Window):
         except Exception as e:
             print("Problem updating monitor views views: %s" % str(e))
 
+    def _is_geometry_valid(self):
+        """
+        Check that all monitor geometries and the screen geometry are sane.
+        Returns False if any dimension is below MIN_MONITOR_DIMENSION.
+        """
+        screen_rect = status.screen.get_screen_geometry()
+        if screen_rect.width < MIN_MONITOR_DIMENSION or screen_rect.height < MIN_MONITOR_DIMENSION:
+            DEBUG("Stage: screen geometry %dx%d is below minimum %d"
+                  % (screen_rect.width, screen_rect.height, MIN_MONITOR_DIMENSION))
+            return False
+
+        n = status.screen.get_n_monitors()
+        for i in range(n):
+            rect = status.screen.get_monitor_geometry(i)
+            if rect.width < MIN_MONITOR_DIMENSION or rect.height < MIN_MONITOR_DIMENSION:
+                DEBUG("Stage: monitor %d geometry %dx%d is below minimum %d"
+                      % (i, rect.width, rect.height, MIN_MONITOR_DIMENSION))
+                return False
+
+        return True
+
+    def _deferred_geometry_recheck(self):
+        """
+        Called after a delay when invalid geometry was detected.
+        Re-checks and emits needs-refresh if now valid.
+        """
+        if self._is_geometry_valid():
+            DEBUG("Stage: deferred geometry re-check passed, refreshing")
+            self.emit("needs-refresh")
+        else:
+            DEBUG("Stage: deferred geometry re-check still invalid, skipping refresh")
+        return False
+
     def on_screen_size_changed(self, screen, data=None):
         """
         The screen changing size should be acted upon immediately, to ensure coverage.
         Wallpapers are secondary.
         """
+        DEBUG("Stage: Received screen size-changed signal")
 
-        DEBUG("Stage: Received screen size-changed signal, refreshing stage")
+        if not self._is_geometry_valid():
+            DEBUG("Stage: invalid geometry detected in size-changed, scheduling deferred re-check")
+            trackers.timer_tracker_get().start("geometry-recheck", 1000, self._deferred_geometry_recheck)
+            return
 
+        trackers.timer_tracker_get().cancel("geometry-recheck")
         self.emit("needs-refresh")
 
     def on_monitors_changed(self, screen, data=None):
@@ -176,8 +216,14 @@ class Stage(Gtk.Window):
         as on_screen_size_changed), and follow up at idle with actual monitor view
         refreshes (wallpapers.)
         """
-        DEBUG("Stage: Received screen monitors-changed signal, refreshing stage")
+        DEBUG("Stage: Received screen monitors-changed signal")
 
+        if not self._is_geometry_valid():
+            DEBUG("Stage: invalid geometry detected in monitors-changed, scheduling deferred re-check")
+            trackers.timer_tracker_get().start("geometry-recheck", 1000, self._deferred_geometry_recheck)
+            return
+
+        trackers.timer_tracker_get().cancel("geometry-recheck")
         self.emit("needs-refresh")
 
     def on_composited_changed(self, screen, data=None):
@@ -424,6 +470,7 @@ class Stage(Gtk.Window):
         self.set_timeout_active(None, False)
 
         trackers.timer_tracker_get().cancel("setup-delayed-components")
+        trackers.timer_tracker_get().cancel("geometry-recheck")
         self.destroy_children()
 
         self.gdk_filter.stop()
@@ -461,6 +508,13 @@ class Stage(Gtk.Window):
 
         for index in monitors:
             monitor = MonitorView(index)
+
+            if (monitor.rect.width < MIN_MONITOR_DIMENSION
+                    or monitor.rect.height < MIN_MONITOR_DIMENSION):
+                DEBUG("Stage: skipping monitor %d with invalid geometry %dx%d"
+                      % (index, monitor.rect.width, monitor.rect.height))
+                monitor.destroy()
+                continue
 
             image = Gtk.Image()
 
@@ -756,13 +810,19 @@ class Stage(Gtk.Window):
 
         if status.InteractiveDebug:
             monitor_n = status.screen.get_primary_monitor()
-            self.rect = status.screen.get_monitor_geometry(monitor_n)
+            new_rect = status.screen.get_monitor_geometry(monitor_n)
         else:
-            self.rect = status.screen.get_screen_geometry()
+            new_rect = status.screen.get_screen_geometry()
 
             scale = status.screen.get_global_scale()
-            self.rect.width *= scale
-            self.rect.height *= scale
+            new_rect.width *= scale
+            new_rect.height *= scale
+
+        if new_rect.width < MIN_MONITOR_DIMENSION or new_rect.height < MIN_MONITOR_DIMENSION:
+            DEBUG("Stage.update_geometry - rejecting invalid geometry: %d x %d" % (new_rect.width, new_rect.height))
+            return
+
+        self.rect = new_rect
 
         DEBUG("Stage.update_geometry - new backdrop position: %d, %d  new size: %d x %d" % (self.rect.x, self.rect.y, self.rect.width, self.rect.height))
 


### PR DESCRIPTION
## Problem

NVIDIA multi-monitor setups can report invalid intermediate geometries (e.g. 8x8 pixels) during mode switches and DPMS wake. This causes:

1. **Screensaver crash** when the stage tries to render with invalid monitor geometry, leading to Gtk widget allocation failures
2. **Orphaned PAM helpers** — when the screensaver crashes, `cinnamon-screensaver-pam-helper` processes (~12MB each) are reparented to PID 1 and accumulate over time

## Solution

**Commit 1: Validate geometry during monitor change events**

- C library (`cs-screen-x11.c`): Add `has_valid_monitor_dimensions()` check with rollback to previous valid state and a 500ms deferred re-check when invalid geometry is detected
- Python stage (`stage.py`): Add `MIN_MONITOR_DIMENSION` (64px) checks before refreshing monitor views, with deferred re-check on invalid geometry
- Both `on_monitors_changed` and `on_screen_size_changed` handlers are guarded in both C and Python layers

**Commit 2: Add exception handler and PAM helper cleanup on exit**

- `sys.excepthook` for proper traceback logging on unhandled exceptions
- `atexit` handler to kill child PAM helper processes
- `SIGTERM` handler for graceful cleanup

## Testing

Tested on a single machine:
- Ubuntu 25.10 (Cinnamon 6.4, cinnamon-screensaver 6.4.0)
- NVIDIA driver 570.133.07, proprietary
- Dual monitor: 3440x1440 (DP) + 2560x1440 (HDMI)
- DPMS sleep/wake cycling over multiple days with no screensaver crashes and zero orphaned PAM helpers

Previously this configuration would crash the screensaver during DPMS wake events. With these guards, invalid geometry is detected and deferred until the driver settles.

**This has only been tested on one machine and has not been widely tested.**

## Disclosure

These patches were developed with AI assistance (Claude Code). The changes have been manually reviewed.

## Related issues

- #298 — Removing or adding a screen during standby crashes screensaver on resume
- #414 — Crashes after suspend/resume with changed monitor configs
- #468 — Hard crash when closing laptop lid while external monitors are attached via USB-C
- #72 — Memory usage increasing significantly over time (PAM helper cleanup partially addresses this)